### PR TITLE
Update the instructions to make it clear a WCF-Relay is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,26 @@ This project framework provides the following features:
 
 ### Prerequisites
 
-- The sample requires an [Azure Relay endpoint](https://docs.microsoft.com/en-us/azure/service-bus-relay/relay-wcf-dotnet-get-started)
+- The sample requires an [Azure Relay Service WCF-Relay endpoint](https://docs.microsoft.com/en-us/azure/service-bus-relay/relay-wcf-dotnet-get-started)
 
 ### Quickstart
 
 1. [Create an Azure Relay namespace](https://docs.microsoft.com/en-us/azure/service-bus-relay/relay-create-namespace-portal).
-2. Set the following values in GridRelayListener Program.cs:  
-* <yourServiceBusNamespace> with the Relay namespace you just created.
-* RootManageSharedAccessKey with the namespace key name if you changed this from the default. *You do not need to do this if you left the name as default.*
-* <yourServiceBusKeyValue> with the key value for your Relay namespace.
-3. Create an [Event Grid Subscription](https://docs.microsoft.com/en-us/azure/event-grid/overview). Put set `https://<yourServiceBusNamespace>/gridservicelistener?code=<yourServiceBusKeyValue>` as the subscriber endpoint.
-4. Run the GridRelayListener sample and send events to your Event Grid subscription using your preferred [event publisher](https://docs.microsoft.com/en-us/azure/event-grid/overview#built-in-publisher-and-handler-integration).
+2. Create a WCF-Relay in the new Azure Relay namespace with the following values:
 
+    Setting | Value
+    ------------ | -------------
+    Name | gridservicelistener
+    RelayType | Http
+    Requires Client Authorization | False
+
+3. Set the following values in GridRelayListener Program.cs:
+    * `"<yourServiceBusNamespace>"` with the Relay namespace you just created.
+    * `"RootManageSharedAccessKey"` with the Relay namespace's shared access policy name if you changed this from the default. *You do not need to do this if you left the name as default.*
+    * `"<yourServiceBusKeyValue>"` with the shared access policy's primary or secondary key value.
+4. Create an [Event Grid Subscription](https://docs.microsoft.com/en-us/azure/event-grid/overview):
+    * Set `https://<yourServiceBusNamespace>/gridservicelistener?code=<yourServiceBusKeyValue>` as the subscriber endpoint.
+5. Run the GridRelayListener sample and send events to your Event Grid subscription using your preferred [event publisher](https://docs.microsoft.com/en-us/azure/event-grid/overview#built-in-publisher-and-handler-integration).
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This project framework provides the following features:
     Setting | Value
     ------------ | -------------
     Name | gridservicelistener
-    RelayType | Http
-    Requires Client Authorization | False
+    Relay Type | Http
+    Requires Client Authorization | Unchecked (False)
 
 3. Set the following values in GridRelayListener Program.cs:
     * `"<yourServiceBusNamespace>"` with the Relay namespace you just created.


### PR DESCRIPTION
## Purpose
Update the instructions to make it clear a WCF-Relay is used and add instructions on how to create the WCF-Relay.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Run through the sample

## Other Information
Feedback was given that it wasn't clear that an Azure Relay *WCF-Relay* was supposed to be used in this example (as opposed to a Azure Relay *Hybrid-Connection*).